### PR TITLE
Fixed a bug in RestRequestResourceBuilder.cs where the data string was not escaped

### DIFF
--- a/YouTrack.Rest.Tests/Requests/SetSubsystemOfAnIssueRequestTests.cs
+++ b/YouTrack.Rest.Tests/Requests/SetSubsystemOfAnIssueRequestTests.cs
@@ -11,7 +11,7 @@ namespace YouTrack.Rest.Tests.Requests
 
         protected override string ExpectedRestResource
         {
-            get { return "/rest/issue/FOO-BAR/execute?command=Subsystem Super System"; }
+            get { return "/rest/issue/FOO-BAR/execute?command=Subsystem%20Super%20System"; }
         }
     }
 }

--- a/YouTrack.Rest.Tests/Requests/SetTypeOfAnIssueRequestTests.cs
+++ b/YouTrack.Rest.Tests/Requests/SetTypeOfAnIssueRequestTests.cs
@@ -15,7 +15,7 @@ namespace YouTrack.Rest.Tests.Requests
 
         protected override string ExpectedRestResource
         {
-            get { return "/rest/issue/FOO-BAR/execute?command=Type Task"; }
+            get { return "/rest/issue/FOO-BAR/execute?command=Type%20Task"; }
         }
     }
 }

--- a/YouTrack.Rest/Requests/RestRequestResourceBuilder.cs
+++ b/YouTrack.Rest/Requests/RestRequestResourceBuilder.cs
@@ -33,7 +33,7 @@ namespace YouTrack.Rest.Requests
 
             foreach (KeyValuePair<string, string> keyValuePair in parameters)
             {
-                parameterString.Append(String.Format("{0}={1}&", keyValuePair.Key, keyValuePair.Value));
+                parameterString.Append(String.Format("{0}={1}&", keyValuePair.Key, Uri.EscapeDataString(keyValuePair.Value)));
             }
 
             return parameterString.ToString().TrimEnd('&');


### PR DESCRIPTION
The data parts of the query string parameters were not escaped and written directly to the URL instead, which causes e.g. authentication to fail when the password contains a reserved character (such as #, &, etc.).

This PR fixes the issue by escaping the data part of query string parameters.
