### PR TITLE
Fixed a bug where retrieving an issue with an empty description caused exceptions

### DIFF
--- a/YouTrack.Rest.Features/General/Issues/GetAnIssue.feature
+++ b/YouTrack.Rest.Features/General/Issues/GetAnIssue.feature
@@ -15,6 +15,11 @@ Scenario: Getting a single issue with comments
 	 When I request the issue
 	 Then it has the comment set
 
+Scenario: Getting a single issue without description
+	Given I have created an issue without description
+	 When I request the issue
+	 Then it has the description set to an empty string
+
 @wip
 Scenario: Getting a single issue with attachments
 	Given I have created an issue

--- a/YouTrack.Rest.Features/General/Issues/GetAnIssue.feature.cs
+++ b/YouTrack.Rest.Features/General/Issues/GetAnIssue.feature.cs
@@ -115,23 +115,42 @@ this.FeatureBackground();
         }
         
         [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Getting a single issue without description")]
+        public virtual void GettingASingleIssueWithoutDescription()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Getting a single issue without description", ((string[])(null)));
+#line 18
+this.ScenarioSetup(scenarioInfo);
+#line 3
+this.FeatureBackground();
+#line 19
+ testRunner.Given("I have created an issue without description");
+#line 20
+  testRunner.When("I request the issue");
+#line 21
+  testRunner.Then("it has the description set to an empty string");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Getting a single issue with attachments")]
         [NUnit.Framework.CategoryAttribute("wip")]
         public virtual void GettingASingleIssueWithAttachments()
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Getting a single issue with attachments", new string[] {
                         "wip"});
-#line 19
+#line 24
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 20
+#line 25
  testRunner.Given("I have created an issue");
-#line 21
+#line 26
    testRunner.And("I have added an attachment to it");
-#line 22
+#line 27
   testRunner.When("I request the issue");
-#line 23
+#line 28
   testRunner.Then("it has the attachment set");
 #line hidden
             this.ScenarioCleanup();
@@ -144,17 +163,17 @@ this.FeatureBackground();
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Getting a single issue with links", new string[] {
                         "wip"});
-#line 26
+#line 31
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 27
+#line 32
  testRunner.Given("I have created an issue");
-#line 28
+#line 33
    testRunner.And("I have linked it to another issue");
-#line 29
+#line 34
   testRunner.When("I request the issue");
-#line 30
+#line 35
   testRunner.Then("it has the link to another issue");
 #line hidden
             this.ScenarioCleanup();
@@ -167,17 +186,17 @@ this.FeatureBackground();
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Getting a single issue with multiple fix versions", new string[] {
                         "wip"});
-#line 33
+#line 38
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 34
+#line 39
  testRunner.Given("I have created an issue");
-#line 35
+#line 40
    testRunner.And("I have added two fix versions to it");
-#line 36
+#line 41
   testRunner.When("I request the issue");
-#line 37
+#line 42
   testRunner.Then("the issue has both fix versions");
 #line hidden
             this.ScenarioCleanup();

--- a/YouTrack.Rest.Features/General/Issues/GetAnIssueSteps.cs
+++ b/YouTrack.Rest.Features/General/Issues/GetAnIssueSteps.cs
@@ -15,6 +15,11 @@ namespace YouTrack.Rest.Features.General.Issues
             SetIssueProxy(StepHelper.CreateIssue("SB", "Testing Fetching", "I can be fetched"));
         }
 
+        [Given(@"I have created an issue without description")]
+        public void GivenIHaveCreatedAnIssueWithoutDescription()
+        {
+            SetIssueProxy(StepHelper.CreateIssue("SB", "Testing Fetching Without Description", ""));
+        }
 
         [When(@"I request the issue")]
         public void WhenIRequestTheIssue()
@@ -51,6 +56,14 @@ namespace YouTrack.Rest.Features.General.Issues
             Assert.That(issue.Updated, Is.GreaterThan(DateTime.MinValue));
             Assert.That(issue.UpdaterName, Is.EqualTo("youtrackapi"));
             Assert.That(issue.VotesCount, Is.EqualTo(0));
+        }
+
+        [Then(@"it has the description set to an empty string")]
+        public void ThenItHasTheDescriptionSetToAnEmptyString()
+        {
+            IIssue issue = ScenarioContext.Current.Get<IIssue>();
+
+            Assert.That(issue.Description, Is.EqualTo(""));
         }
 
         [Given(@"I have given it a comment")]

--- a/YouTrack.Rest/Deserialization/Issue.cs
+++ b/YouTrack.Rest/Deserialization/Issue.cs
@@ -18,7 +18,7 @@ namespace YouTrack.Rest.Deserialization
 
             issue.CommentsCount = GetInt32("commentsCount");
             issue.Created = GetDateTime("created");
-            issue.Description = GetString("description");
+            issue.Description = GetString("description", "");
             issue.NumberInProject = GetInt32("numberInProject");
             issue.Priority = GetString("priority");
             issue.ProjectShortName = GetString("projectShortName");
@@ -56,11 +56,15 @@ namespace YouTrack.Rest.Deserialization
             throw new IssueWrappingException(String.Format("Issue [{0}] has zero or multiple datetime values for field [{1}].", Id, name));
         }
 
-        private string GetString(string name)
+        private string GetString(string name, string defaultValue = null)
         {
             if (HasSingleFieldFor(name))
             {
                 return GetSingleFieldFor(name).GetValue();
+            }
+            else if (defaultValue != null)
+            {
+                return defaultValue;
             }
 
             throw new IssueWrappingException(String.Format("Issue [{0}] has zero or multiple string values for field [{1}].", Id, name));


### PR DESCRIPTION
This PR fixes the case where no "description" field is returned via the API, as happens when the description is empty. It assigns an empty string to the Description property as a default value in this case.

I also added an appropriate test for this behavior.
