### PR TITLE
Reverted Castle.Core dependency to 3.0 <= x < 4

### DIFF
--- a/YouTrack.Rest/YouTrack.Rest.csproj.nuspec
+++ b/YouTrack.Rest/YouTrack.Rest.csproj.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>YouTrack.Rest</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <authors>Sauli Tähkäpää</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Another .NET client for the YouTrack 4.0 REST API</description>


### PR DESCRIPTION
Here are some more goodies! Unnecessary 3.2+ dependency to Castle.Core reverted back to 3.0+.
