### PR TITLE
Searching of Issues and retrieving change history

### DIFF
--- a/YouTrack.Rest/Change.cs
+++ b/YouTrack.Rest/Change.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace YouTrack.Rest
+{
+    public class Change: IChange
+    {
+        public Change()
+        {
+            ChangedFields = new Dictionary<string, IChangedField>(StringComparer.InvariantCultureIgnoreCase);
+        }
+
+        public DateTime Updated { get; internal set; }
+
+        public string UpdaterName { get; internal set; }
+
+        public IDictionary<string, IChangedField> ChangedFields { get; private set; }
+    }
+}

--- a/YouTrack.Rest/ChangedField.cs
+++ b/YouTrack.Rest/ChangedField.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using YouTrack.Rest.Deserialization;
+
+namespace YouTrack.Rest
+{
+    class ChangedField : IChangedField
+    {
+        public ChangedField(Field field)
+        {
+            Name = field.Name;
+            
+            if (null != field.Values)
+                Values = field.Values.ConvertAll(v => v.ToString());
+            
+            if (null != field.NewValues)
+                NewValues = field.NewValues.ConvertAll(v => v.ToString());
+
+            if (null != field.OldValues)
+                OldValues = field.OldValues.ConvertAll(v => v.ToString());
+        }
+
+        public string Name { get; private set; }
+
+        public IEnumerable<string> Values { get; private set; }
+
+        public IEnumerable<string> OldValues { get; private set; }
+
+        public IEnumerable<string> NewValues { get; private set; }
+    }
+}

--- a/YouTrack.Rest/Deserialization/Change.cs
+++ b/YouTrack.Rest/Deserialization/Change.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+
+namespace YouTrack.Rest.Deserialization
+{
+    class Change : HasFieldsBase
+    {
+        public Change() : base("Change")
+        {
+        }
+
+        public IChange GetChange(IConnection connection)
+        {
+            Rest.Change change = new Rest.Change();
+
+            MapTo(change);
+
+            return change;
+        }
+
+        public void MapTo(Rest.Change change)
+        {
+            change.UpdaterName = GetString("updaterName", "");
+            change.Updated = GetDateTime("updated");
+
+            MapFields(change.ChangedFields);
+        }
+
+        private void MapFields(IDictionary<string, IChangedField> fields)
+        {
+            fields.Clear();
+
+            foreach (Field field in Fields)
+            {
+                if (!string.IsNullOrEmpty(field.Name))
+                {
+                    fields[field.Name] = new ChangedField(field);
+                }
+            }
+        }
+    }
+}

--- a/YouTrack.Rest/Deserialization/ChangeCollection.cs
+++ b/YouTrack.Rest/Deserialization/ChangeCollection.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace YouTrack.Rest.Deserialization
+{
+    class ChangeCollection
+    {
+        public List<Change> Changes { get; set; }
+
+        public IEnumerable<IChange> GetChanges(IConnection connection)
+        {
+            return Changes.Select(c => c.GetChange(connection)).ToArray();
+        } 
+    }
+}

--- a/YouTrack.Rest/Deserialization/Field.cs
+++ b/YouTrack.Rest/Deserialization/Field.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using RestSharp.Deserializers;
 using YouTrack.Rest.Exceptions;
 
 namespace YouTrack.Rest.Deserialization
@@ -8,7 +9,12 @@ namespace YouTrack.Rest.Deserialization
     class Field
     {
         public string Name { get; set; }
+        public string Type { get; set; }
         public List<Value_> Values { get; set; }
+
+        // issue field value changes
+        public List<NewValue> NewValues { get; set; }
+        public List<OldValue> OldValues { get; set; }
 
         public string GetValue()
         {

--- a/YouTrack.Rest/Deserialization/HasFieldsBase.cs
+++ b/YouTrack.Rest/Deserialization/HasFieldsBase.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YouTrack.Rest.Exceptions;
+
+namespace YouTrack.Rest.Deserialization
+{
+    abstract class HasFieldsBase
+    {
+        private readonly string type;
+
+        public string Id { get; set; }
+
+        public List<Field> Fields { get; set; }
+
+        protected HasFieldsBase(string type)
+        {
+            this.type = type;
+        }
+
+        protected bool HasFieldFor(string name)
+        {
+            return Fields.Any(GetCompareNamesPredicate(name));
+        }
+
+        protected bool HasSingleFieldFor(string name)
+        {
+            return Fields.Count(GetCompareNamesPredicate(name)) == 1;
+        }
+
+        protected Field GetSingleFieldFor(string name)
+        {
+            return Fields.Single(GetCompareNamesPredicate(name));
+        }
+
+        private Func<Field, bool> GetCompareNamesPredicate(string name)
+        {
+            return f => f.Name.ToUpper() == name.ToUpper();
+        }
+
+        protected int GetInt32(string name)
+        {
+            if (HasSingleFieldFor(name))
+            {
+                return GetSingleFieldFor(name).GetInt32();
+            }
+
+            throw new IssueDeserializationException(String.Format("{0} '{1}' has zero or multiple integer values for field '{2}'.", type, Id, name));
+        }
+
+        protected DateTime GetDateTime(string name)
+        {
+            if (HasSingleFieldFor(name))
+            {
+                return GetSingleFieldFor(name).GetDateTime();
+            }
+
+            throw new IssueDeserializationException(String.Format("{0} '{1}' has zero or multiple datetime values for field '{2}'.", type, Id, name));
+        }
+
+        protected string GetString(string name, string defaultValue = null)
+        {
+            if (!HasFieldFor(name) && defaultValue != null)
+            {
+                return defaultValue;
+            }
+
+            if (HasSingleFieldFor(name))
+            {
+                return GetSingleFieldFor(name).GetValue();
+            }
+
+            throw new IssueDeserializationException(String.Format("{0} '{1}' has zero or multiple string values for field '{2}'.", type, Id, name));
+        }
+    }
+}

--- a/YouTrack.Rest/Deserialization/Issue.cs
+++ b/YouTrack.Rest/Deserialization/Issue.cs
@@ -1,16 +1,16 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using YouTrack.Rest.Exceptions;
 
 namespace YouTrack.Rest.Deserialization
 {
     //Has to have name Issue for RestSharp deserialization to work properly.
-    class Issue
+    class Issue : HasFieldsBase
     {
-        public string Id { get; set; }
-        public List<Field> Fields { get; set; }
-        public List<Comment> Comments { get; set; } 
+        public List<Comment> Comments { get; set; }
+
+        public Issue() : base("Issue")
+        {
+        }
 
         public virtual IIssue GetIssue(IConnection connection)
         {
@@ -19,61 +19,6 @@ namespace YouTrack.Rest.Deserialization
             MapTo(issue, connection);
 
             return issue;
-        }
-
-        private int GetInt32(string name)
-        {
-            if (HasSingleFieldFor(name))
-            {
-                return GetSingleFieldFor(name).GetInt32();
-            }
-
-            throw new IssueDeserializationException(String.Format("Issue '{0}' has zero or multiple integer values for field '{1}'.", Id, name));
-        }
-
-        private DateTime GetDateTime(string name)
-        {
-            if(HasSingleFieldFor(name))
-            {
-                return GetSingleFieldFor(name).GetDateTime();
-            }
-
-            throw new IssueDeserializationException(String.Format("Issue '{0}' has zero or multiple datetime values for field '{1}'.", Id, name));
-        }
-
-        private string GetString(string name, string defaultValue = null)
-        {
-            if(!HasFieldFor(name) && defaultValue != null)
-            {
-                return defaultValue;
-            }
-
-            if (HasSingleFieldFor(name))
-            {
-                return GetSingleFieldFor(name).GetValue();
-            }
-
-            throw new IssueDeserializationException(String.Format("Issue '{0}' has zero or multiple string values for field '{1}'.", Id, name));
-        }
-
-        private bool HasFieldFor(string name)
-        {
-            return Fields.Any(GetCompareNamesPredicate(name));
-        }
-
-        private bool HasSingleFieldFor(string name)
-        {
-            return Fields.Count(GetCompareNamesPredicate(name)) == 1;
-        }
-
-        private Field GetSingleFieldFor(string name)
-        {
-            return Fields.Single(GetCompareNamesPredicate(name));
-        }
-
-        private Func<Field, bool> GetCompareNamesPredicate(string name)
-        {
-            return f => f.Name.ToUpper() == name.ToUpper();
         }
 
         public void MapTo(Rest.Issue issue, IConnection connection)

--- a/YouTrack.Rest/Deserialization/Value_.cs
+++ b/YouTrack.Rest/Deserialization/Value_.cs
@@ -1,5 +1,8 @@
 namespace YouTrack.Rest.Deserialization
 {
+    internal class NewValue : Value_ { }
+    internal class OldValue : Value_ { }
+
     internal class Value_
     {
         public string Value { get; set; }

--- a/YouTrack.Rest/IChange.cs
+++ b/YouTrack.Rest/IChange.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace YouTrack.Rest
+{
+    public interface IChange
+    {
+        DateTime Updated { get; }
+        string UpdaterName { get; }
+
+        IDictionary<string, IChangedField> ChangedFields { get; }
+    }
+}

--- a/YouTrack.Rest/IChangedField.cs
+++ b/YouTrack.Rest/IChangedField.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace YouTrack.Rest
+{
+    public interface IChangedField
+    {
+        string Name { get; }
+        IEnumerable<string> Values { get; }
+        IEnumerable<string> OldValues { get; }
+        IEnumerable<string> NewValues { get; }
+    }
+}

--- a/YouTrack.Rest/IIssueActions.cs
+++ b/YouTrack.Rest/IIssueActions.cs
@@ -15,5 +15,6 @@ namespace YouTrack.Rest
         void SetType(string type, string group = null);
         void ApplyCommand(string command, string group = null);
         void ApplyCommands(params string[] commands);
+        IEnumerable<IChange> ChangeHistory { get; }
     }
 }

--- a/YouTrack.Rest/IssueActions.cs
+++ b/YouTrack.Rest/IssueActions.cs
@@ -47,6 +47,22 @@ namespace YouTrack.Rest
             Connection.Post(request);
         }
 
+        private IEnumerable<IChange> changes; 
+
+        public IEnumerable<IChange> ChangeHistory
+        {
+            get { return changes ?? (changes = GetChanges()); }
+        }
+
+        private IEnumerable<IChange> GetChanges()
+        {
+            GetChangeHistoryOfAnIssueRequest request = new GetChangeHistoryOfAnIssueRequest(Id);
+
+            ChangeCollection changeCollection = Connection.Get<ChangeCollection>(request);
+
+            return changeCollection.GetChanges(Connection);
+        }
+
         public void SetSubsystem(string subsystem, string group = null)
         {
             ApplyCommand(Commands.SetSubsystem(subsystem), group);

--- a/YouTrack.Rest/Repositories/IIssueRepository.cs
+++ b/YouTrack.Rest/Repositories/IIssueRepository.cs
@@ -1,9 +1,15 @@
+using System.Collections.Generic;
+
 namespace YouTrack.Rest.Repositories
 {
     public interface IIssueRepository
     {
         IIssue CreateIssue(string project, string summary, string description, string group = null);
         IIssue GetIssue(string issueId);
+        IEnumerable<IIssue> Search(string query);
+        IEnumerable<IIssue> Search(string query, params string[] withFields);
+        IEnumerable<IIssue> Search(string query, int maximumNumberOfRecordsToReturn, int startFrom);
+        IEnumerable<IIssue> Search(string query, string[] withFields, int maximumNumberOfRecordsToReturn, int startFrom);
         void DeleteIssue(string issueId);
         bool IssueExists(string issueId);
     }

--- a/YouTrack.Rest/Repositories/IssueRepository.cs
+++ b/YouTrack.Rest/Repositories/IssueRepository.cs
@@ -1,7 +1,7 @@
+using System.Collections.Generic;
 using System.Linq;
 using YouTrack.Rest.Exceptions;
 using YouTrack.Rest.Factories;
-using YouTrack.Rest.Requests;
 using YouTrack.Rest.Requests.Issues;
 
 namespace YouTrack.Rest.Repositories
@@ -30,6 +30,41 @@ namespace YouTrack.Rest.Repositories
         public IIssue GetIssue(string issueId)
         {
             return issueFactory.CreateIssue(issueId, connection);
+        }
+
+        public IEnumerable<IIssue> Search(string query)
+        {
+            SearchRequest searchRequest = new SearchRequest(query);
+
+            return Search(searchRequest);
+        }
+
+        public IEnumerable<IIssue> Search(string query, params string[] withFields)
+        {
+            SearchRequest searchRequest = new SearchRequest(query, withFields);
+
+            return Search(searchRequest);
+        }
+
+        public IEnumerable<IIssue> Search(string query, int maximumNumberOfRecordsToReturn, int startFrom)
+        {
+            SearchRequest searchRequest = new SearchRequest(query, null, maximumNumberOfRecordsToReturn, startFrom);
+
+            return Search(searchRequest);
+        }
+
+        public IEnumerable<IIssue> Search(string query, string[] withFields, int maximumNumberOfRecordsToReturn, int startFrom)
+        {
+            SearchRequest searchRequest = new SearchRequest(query, withFields, maximumNumberOfRecordsToReturn, startFrom);
+
+            return Search(searchRequest);
+        }
+
+        private IEnumerable<IIssue> Search(SearchRequest request)
+        {
+            List<Deserialization.Issue> issues = connection.Get<List<Deserialization.Issue>>(request);
+
+            return issues.Select(i => i.GetIssue(connection));
         }
 
         public void DeleteIssue(string issueId)

--- a/YouTrack.Rest/Requests/Issues/GetChangeHistoryOfAnIssueRequest.cs
+++ b/YouTrack.Rest/Requests/Issues/GetChangeHistoryOfAnIssueRequest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace YouTrack.Rest.Requests.Issues
+{
+    class GetChangeHistoryOfAnIssueRequest : YouTrackRequest, IYouTrackGetRequest
+    {
+        public GetChangeHistoryOfAnIssueRequest(string issueId)
+            : base(String.Format("/rest/issue/{0}/changes", issueId))
+        {
+        }
+    }
+}

--- a/YouTrack.Rest/Requests/Issues/SearchRequest.cs
+++ b/YouTrack.Rest/Requests/Issues/SearchRequest.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+
+namespace YouTrack.Rest.Requests.Issues
+{
+    class SearchRequest : YouTrackRequest, IYouTrackGetRequest
+    {
+        public SearchRequest(string query, string[] withFields = null, int max = -1, int from = -1)
+            : base("/rest/issue")
+        {
+            if (!string.IsNullOrWhiteSpace(query))
+                ResourceBuilder.AddParameter("filter", query);
+
+            if (null != withFields)
+            {
+                withFields = withFields.Where(f => !string.IsNullOrWhiteSpace(f))
+                                       .Select(f => f.Trim())
+                                       .ToArray();
+
+                if (withFields.Length > 0)
+                    ResourceBuilder.AddMultiValueParameter("with", withFields);
+            }
+
+            if (max > 0)
+                ResourceBuilder.AddParameter("max", max.ToString());
+            if (from >= 0)
+                ResourceBuilder.AddParameter("from", from.ToString());
+        }
+    }
+}

--- a/YouTrack.Rest/Requests/RestRequestResourceBuilder.cs
+++ b/YouTrack.Rest/Requests/RestRequestResourceBuilder.cs
@@ -49,6 +49,17 @@ namespace YouTrack.Rest.Requests
             }
         }
 
+        public void AddMultiValueParameter(string parameterName, IEnumerable<string> parameterValues)
+        {
+            foreach (var parameterValue in parameterValues)
+            {
+                if (!String.IsNullOrEmpty(parameterValue))
+                {
+                    parameters.Add(parameterName, parameterValue);
+                }
+            }
+        }
+
         private void ThrowIfParameterAlreadyAdded(string parameterName)
         {
             if (parameters.ContainsKey(parameterName))

--- a/YouTrack.Rest/YouTrack.Rest.csproj
+++ b/YouTrack.Rest/YouTrack.Rest.csproj
@@ -50,14 +50,19 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Change.cs" />
+    <Compile Include="ChangedField.cs" />
+    <Compile Include="Deserialization\Change.cs" />
     <Compile Include="Commands.cs" />
     <Compile Include="Comment.cs" />
     <Compile Include="Connection.cs" />
+    <Compile Include="Deserialization\ChangeCollection.cs" />
     <Compile Include="Deserialization\Comment.cs" />
     <Compile Include="Deserialization\CommentCollection.cs" />
     <Compile Include="Deserialization\Field.cs" />
     <Compile Include="Deserialization\FileUrl.cs" />
     <Compile Include="Deserialization\FileUrlCollection.cs" />
+    <Compile Include="Deserialization\HasFieldsBase.cs" />
     <Compile Include="Deserialization\Issue.cs" />
     <Compile Include="Deserialization\Project.cs" />
     <Compile Include="Deserialization\Subsystem.cs" />
@@ -84,6 +89,8 @@
     <Compile Include="Factories\RestFileRequestFactory.cs" />
     <Compile Include="Factories\RestRequestFactory.cs" />
     <Compile Include="IAttachment.cs" />
+    <Compile Include="IChange.cs" />
+    <Compile Include="IChangedField.cs" />
     <Compile Include="IComment.cs" />
     <Compile Include="IConnection.cs" />
     <Compile Include="IIssueActions.cs" />
@@ -117,6 +124,7 @@
     <Compile Include="Requests\Issues\CreateNewIssueRequest.cs" />
     <Compile Include="Requests\Issues\DeleteIssueRequest.cs" />
     <Compile Include="Requests\Issues\GetAttachmentsOfAnIssueRequest.cs" />
+    <Compile Include="Requests\Issues\GetChangeHistoryOfAnIssueRequest.cs" />
     <Compile Include="Requests\Issues\GetCommentsOfAnIssueRequest.cs" />
     <Compile Include="Requests\Issues\GetIssueRequest.cs" />
     <Compile Include="Requests\Issues\GetIssuesInAProjectRequest.cs" />
@@ -134,6 +142,7 @@
     <Compile Include="Requests\Projects\GetProjectRequest.cs" />
     <Compile Include="Requests\Projects\GetProjectSubsystemsRequest.cs" />
     <Compile Include="Requests\RestRequestResourceBuilder.cs" />
+    <Compile Include="Requests\Issues\SearchRequest.cs" />
     <Compile Include="Requests\Users\AddUserToGroupRequest.cs" />
     <Compile Include="Requests\Users\AssignRoleToUserGroupRequest.cs" />
     <Compile Include="Requests\Users\CreateANewUserRequest.cs" />


### PR DESCRIPTION
- Added support for searching for issues. ref: https://confluence.jetbrains.com/display/YTD6/Get+the+List+of+Issues
  probably not compatible with YT3 since this method is not mentioned in documentation.
- Added support for retrieving change history of a single issue. ref: https://confluence.jetbrains.com/display/YTD6/Get+Historical+Changes+of+an+Issue
  You can use NewValue/OldValue properties for changed field values, and Values for fields set in that change
